### PR TITLE
Updated Integer to be Long for worldUploadTimes

### DIFF
--- a/universalis-rest/src/main/java/de/chojo/universalis/entities/views/CurrentlyShownView.java
+++ b/universalis-rest/src/main/java/de/chojo/universalis/entities/views/CurrentlyShownView.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 public record CurrentlyShownView(@JsonProperty("itemID") Item item,
                                  @JsonProperty("worldID") World world,
-                                 @JsonProperty("worldUploadTimes") @Nullable Map<String, Integer> worldUploadTimes,
+                                 @JsonProperty("worldUploadTimes") @Nullable Map<String, Long> worldUploadTimes,
                                  @JsonProperty("lastUploadTime") @JsonDeserialize(converter = MillisDateTimeConverter.class) LocalDateTime lastUploadTime,
                                  @JsonProperty("listings") List<ListingView> listingViews,
                                  @JsonProperty("recentHistory") List<SaleView> recentHistory,


### PR DESCRIPTION
As mentioned [here](https://github.com/rainbowdashlabs/universalis-java/issues/82), I am running into the following exception when trying to use the REST client to obtain data from the market board:
```
java.lang.RuntimeException: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (1712856421592) out of range of int (-2147483648 - 2147483647)
 at [Source: (StringReader); line: 1, column: 141297] (through reference chain: de.chojo.universalis.entities.views.CurrentlyShownView["worldUploadTimes"])
	at de.chojo.universalis.rest.UniversalisRestImpl.getAndMapInternal(UniversalisRestImpl.java:232) ~[universalis-rest-1.3.1.jar:na]
	at de.chojo.universalis.rest.UniversalisRestImpl.lambda$getAsyncAndMap$0(UniversalisRestImpl.java:203) ~[universalis-rest-1.3.1.jar:na]
```

Not sure if the fix would be as simple as my PR, but I thought I would as least try to help. Thanks!

Logan